### PR TITLE
fix: Wrap title in an array

### DIFF
--- a/src/sourdough-toast.js
+++ b/src/sourdough-toast.js
@@ -301,7 +301,7 @@ class Toast {
 
     const contentChildren = [];
 
-    const title = h("div", { dataset: { title: "" } }, opts.title);
+    const title = h("div", { dataset: { title: "" } }, [opts.title]);
 
     contentChildren.push(title);
 


### PR DESCRIPTION
Occasionally I get an exception `Uncaught TypeError: children is not iterable` at [line](https://github.com/mikker/sourdough-toast/blob/main/src/sourdough-toast.js#L46)

This PR wraps the title in an array to prevent error in `h()` call and iterating over its children.

thx