### PR TITLE
Add closeButton option to toasts

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -202,6 +202,7 @@ toast("Hi!");</code></pre>
             <td><code>closeButton</code></td>
             <td><code>false</code></td>
             <td>Show close button</td>
+          </tr>
         </tbody>
       </table>
     </section>

--- a/example/index.html
+++ b/example/index.html
@@ -35,9 +35,7 @@
 
       window.toast = toast;
 
-      const sourdough = new Sourdough({
-        duration: 4000000
-      });
+      const sourdough = new Sourdough();
 
       window.addEventListener("DOMContentLoaded", () => {
         sourdough.boot();

--- a/example/index.html
+++ b/example/index.html
@@ -35,7 +35,9 @@
 
       window.toast = toast;
 
-      const sourdough = new Sourdough();
+      const sourdough = new Sourdough({
+        duration: 4000000
+      });
 
       window.addEventListener("DOMContentLoaded", () => {
         sourdough.boot();
@@ -132,6 +134,9 @@ toast("Hi!");</code></pre>
         <button class="btn" onclick="toast.error('Oh no, we failed')">
           Error
         </button>
+        <button class="btn" onclick="toast.message({ title: 'Title', description: 'Description', closeButton: true })">
+          With Close Button
+        </button>
       </div>
     </section>
     <section>
@@ -195,6 +200,10 @@ toast("Hi!");</code></pre>
             <td><code>false</code></td>
             <td>More colorful toasts</td>
           </tr>
+          <tr>
+            <td><code>closeButton</code></td>
+            <td><code>false</code></td>
+            <td>Show close button</td>
         </tbody>
       </table>
     </section>

--- a/src/sourdough-toast.css
+++ b/src/sourdough-toast.css
@@ -11,9 +11,6 @@ html[dir="ltr"],
   --toast-svg-margin-end: 0px;
   --toast-button-margin-start: auto;
   --toast-button-margin-end: 0;
-  --toast-close-button-start: 0;
-  --toast-close-button-end: unset;
-  --toast-close-button-transform: translate(-35%, -35%);
 }
 
 html[dir="rtl"],
@@ -24,9 +21,6 @@ html[dir="rtl"],
   --toast-svg-margin-end: -1px;
   --toast-button-margin-start: 0;
   --toast-button-margin-end: auto;
-  --toast-close-button-start: unset;
-  --toast-close-button-end: 0;
-  --toast-close-button-transform: translate(35%, -35%);
 }
 
 [data-sourdough-toaster] {
@@ -34,6 +28,8 @@ html[dir="rtl"],
   --font-family: system-ui, sans-serif;
   --background: white;
   --foreground: hsl(0deg 0% 0%);
+  --toast-close-button-top: 10px;
+  --toast-close-button-inset-inline-end: 10px;
 
   position: fixed;
   box-sizing: border-box;
@@ -209,33 +205,19 @@ html[dir="rtl"],
 
 [data-sourdough-toast] [data-close-button] {
   position: absolute;
-  left: var(--toast-close-button-start);
-  right: var(--toast-close-button-end);
-  top: 0;
+  top: var(--toast-close-button-top);
+  inset-inline-end: var(--toast-close-button-inset-inline-end);
   height: 20px;
   width: 20px;
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 0;
-  background: var(--gray1);
-  color: var(--gray12);
-  border: 1px solid var(--gray4);
-  transform: var(--toast-close-button-transform);
-  border-radius: 50%;
+  color: var(--foreground);
   opacity: 0;
   cursor: pointer;
   z-index: 1;
-  transition:
-    opacity 100ms,
-    background 200ms,
-    border-color 200ms;
-}
-
-[data-sourdough-toast] [data-close-button]:focus-visible {
-  box-shadow:
-    0px 4px 12px rgba(0, 0, 0, 0.1),
-    0 0 0 2px rgba(0, 0, 0, 0.2);
+  transition: opacity 100ms;
 }
 
 [data-sourdough-toast] [data-disabled="true"] {
@@ -243,18 +225,17 @@ html[dir="rtl"],
 }
 
 [data-sourdough-toast]:hover [data-close-button] {
-  opacity: 1;
+  opacity: .3;
 }
 [data-sourdough-toast]:focus [data-close-button] {
-  opacity: 1;
+  opacity: .3;
 }
 [data-sourdough-toast]:focus-within [data-close-button] {
-  opacity: 1;
+  opacity: .3;
 }
 
 [data-sourdough-toast]:hover [data-close-button]:hover {
-  background: var(--gray2);
-  border-color: var(--gray5);
+  opacity: 1;
 }
 
 /* Leave a ghost div to avoid setting hover to false when swiping out */

--- a/src/sourdough-toast.js
+++ b/src/sourdough-toast.js
@@ -10,6 +10,7 @@ const DEFAULT_OPTIONS = {
   expandedByDefault: false,
   yPosition: "bottom",
   xPosition: "right",
+  closeButton: false,
 };
 
 let toastsCounter = 0;
@@ -182,6 +183,7 @@ const icons = {
       }),
     ],
   ),
+  close: h("svg", svgAttrs, [h("path", { d: "M6 18 18 6M6 6l12 12" })]),
 };
 
 function getDocumentDirection() {
@@ -297,6 +299,25 @@ class Toast {
       children.push(
         h("div", { dataset: { icon: "" } }, [icon.cloneNode(true)]),
       );
+    }
+
+    const showCloseButton = opts.closeButton === true || (this.sourdough.opts.closeButton === true && opts.closeButton !== false);
+    if (showCloseButton) {
+      const closeButton = h(
+        "button",
+        {
+          dataset: { closeButton: "" },
+          type: "button",
+          ariaLabel: "Close"
+        },
+        [icons.close.cloneNode(true)],
+      );
+
+      closeButton.addEventListener("click", () => {
+        this.remove();
+      });
+
+      children.push(closeButton);
     }
 
     const contentChildren = [];

--- a/tests/index.html
+++ b/tests/index.html
@@ -28,5 +28,6 @@
     <button onclick="toast.info('Info toast')">Info</button>
     <button onclick="toast.warning('Warning toast')">Warning</button>
     <button onclick="toast.error('Error toast')">Error</button>
+    <button onclick="toast.message({ title: 'With Close Button', closeButton: true })">With Close Button</button>
   </body>
 </html>

--- a/tests/sourdough-toast.spec.js
+++ b/tests/sourdough-toast.spec.js
@@ -49,3 +49,20 @@ test("toasts don't dismiss when hovered", async ({ page }) => {
 
   await expect(page.locator("[data-sourdough-toast]")).toHaveCount(1);
 });
+
+test("toast with closeButton:true renders a close button", async ({ page }) => {
+  await page.getByRole("button", { name: "With Close Button" }).click();
+  await expect(page.locator("[data-close-button]")).toHaveCount(1);
+});
+
+test("clicking close button removes the toast", async ({ page }) => {
+  await page.getByRole("button", { name: "With Close Button" }).click();
+  await expect(page.locator("[data-sourdough-toast]")).toHaveCount(1);
+
+  await page.locator("[data-close-button]").click();
+
+  await expect(page.locator("[data-sourdough-toast][data-removed='true']")).toBeVisible();
+
+  await page.waitForTimeout(500);
+  await expect(page.locator("[data-sourdough-toast]")).toHaveCount(0);
+});


### PR DESCRIPTION
https://github.com/user-attachments/assets/038d9323-5b77-4cc4-ac7d-9e85e4acdd42

This PR introduces a new `closeButton` option that adds a dismiss button to toasts — either globally or on a per-toast basis.

✨ **Features**

- **Global support**: Enable `closeButton` for all toasts
- **Per-toast support**: Add or remove `closeButton` individually
- Clicking the `closeButton` immediately removes the toast
- Basic styles included 

💬 **Motivation**

This makes it easy to give users more control over toast messages by letting them dismiss notifications manually. Whether you want all toasts to be closable or just a few, this option keeps the API clean and flexible.

🙌 **Thanks for this awesome repo!**

Sourdough Toast is such a joy to use—minimal, clean, and just works out of the box. Happy to contribute a tiny bit to it!