### PR TITLE
feat: add `persist` option for toasts that stay visible until manually closed

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -139,6 +139,9 @@ toast("Hi!");</code></pre>
         <button class="btn" onclick="toast.message({ title: 'Confirmation needed', description: h('div', {class: 'flex justify-between items-center'}, [h('span', {}, 'Please confirm your action'), h('button', { dataset: { toastDismiss: true }, class: 'btn'}, ['Confirm'])]) })">
           With HTML
         </button>
+        <button class="btn" onclick="toast('This toast will stay until dismissed', { persist: true })">
+          Persist
+        </button>
       </div>
     </section>
     <section>

--- a/src/sourdough-toast.css
+++ b/src/sourdough-toast.css
@@ -169,6 +169,10 @@ html[dir="rtl"],
   width: 100%;
 }
 
+[data-sourdough-toast]:has([data-close-button]) [data-content] {
+  padding-inline-end: 24px;
+}
+
 [data-sourdough-toast] [data-button] {
   border-radius: 4px;
   padding-left: 8px;
@@ -240,6 +244,14 @@ html[dir="rtl"],
 }
 
 [data-sourdough-toast]:hover [data-close-button]:hover {
+  opacity: 1;
+}
+
+[data-sourdough-toast][data-persist="true"] [data-close-button] {
+  opacity: .3;
+}
+
+[data-sourdough-toast][data-persist="true"] [data-close-button]:hover {
   opacity: 1;
 }
 

--- a/src/sourdough-toast.js
+++ b/src/sourdough-toast.js
@@ -301,7 +301,7 @@ class Toast {
       );
     }
 
-    const showCloseButton = opts.closeButton === true || (this.sourdough.opts.closeButton === true && opts.closeButton !== false);
+    const showCloseButton = opts.persist || opts.closeButton === true || (this.sourdough.opts.closeButton === true && opts.closeButton !== false);
     if (showCloseButton) {
       const closeButton = h(
         "button",
@@ -349,19 +349,25 @@ class Toast {
 
     children.push(content);
 
+    const liDataset = {
+      sourdoughToast: "",
+      expanded: sourdough.opts.expanded,
+      styled: true,
+      swiping: false,
+      swipeOut: false,
+      type: opts.type,
+      yPosition: sourdough.opts.yPosition,
+      xPosition: sourdough.opts.xPosition,
+    };
+
+    if (opts.persist) {
+      liDataset.persist = "true";
+    }
+
     const li = h(
       "li",
       {
-        dataset: {
-          sourdoughToast: "",
-          expanded: sourdough.opts.expanded,
-          styled: true,
-          swiping: false,
-          swipeOut: false,
-          type: opts.type,
-          yPosition: sourdough.opts.yPosition,
-          xPosition: sourdough.opts.xPosition,
-        },
+        dataset: liDataset,
         style: {},
       },
       [children],
@@ -377,8 +383,10 @@ class Toast {
 
     state.touch();
 
-    this.timeLeft = this.sourdough.opts.duration;
-    this.resume();
+    if (!this.opts.persist) {
+      this.timeLeft = this.sourdough.opts.duration;
+      this.resume();
+    }
   };
 
   remove = () => {
@@ -391,12 +399,14 @@ class Toast {
   };
 
   pause = () => {
+    if (this.opts.persist) return;
     this.paused = true;
     this.timeLeft = this.timeLeft - (Date.now() - this.startedAt);
     clearTimeout(this.timer);
   };
 
   resume = () => {
+    if (this.opts.persist) return;
     this.paused = false;
     this.startedAt = Date.now();
     this.timer = setTimeout(this.remove, this.timeLeft);
@@ -459,8 +469,13 @@ class Sourdough {
     this.expanded = state.expanded || state.interacting;
     this.list.dataset.expanded = this.expanded;
 
-    // Get first X toasts
-    const toasts = state.toasts.slice(-this.opts.maxToasts);
+    // Get last X toasts, but persisted toasts don't count toward the limit
+    const nonPersisted = state.toasts.filter((t) => !t.persist);
+    const capped = nonPersisted.slice(-this.opts.maxToasts);
+    const cappedIds = new Set(capped.map((t) => t.id));
+    const toasts = state.toasts.filter(
+      (t) => t.persist || cappedIds.has(t.id),
+    );
 
     // Render and cache toasts that haven't been rendered yet
     const renderedIds = [];
@@ -546,8 +561,8 @@ class Sourdough {
 
 const state = new Store();
 
-const toast = (title) => {
-  state.create({ title });
+const toast = (title, opts = {}) => {
+  state.create({ title, ...opts });
 };
 toast.message = ({ title, description, ...opts }) => {
   state.create({ title, description, ...opts });

--- a/tests/index.html
+++ b/tests/index.html
@@ -28,7 +28,38 @@
     <button onclick="toast.info('Info toast')">Info</button>
     <button onclick="toast.warning('Warning toast')">Warning</button>
     <button onclick="toast.error('Error toast')">Error</button>
-    <button onclick="toast.message({ title: 'With Close Button', closeButton: true })">With Close Button</button>
-    <button onclick="toast.message({ title: 'With HTML', html: true, description: '<strong>HTML</strong> content <button data-toast-dismiss>Confirm</button>' })">With HTML</button>
+    <button
+      onclick="toast.message({ title: 'With Close Button', closeButton: true })"
+    >
+      With Close Button
+    </button>
+    <button
+      onclick="
+        toast.message({
+          title: 'With HTML',
+          html: true,
+          description:
+            '<strong>HTML</strong> content <button data-toast-dismiss>Confirm</button>',
+        })
+      "
+    >
+      With HTML
+    </button>
+    <button onclick="toast('Persistent toast', { persist: true })">
+      Persist
+    </button>
+    <button onclick="toast.error('Persistent error', { persist: true })">
+      Persist Error
+    </button>
+    <button
+      onclick="
+        toast(
+          'This is a much longer persistent toast message that should wrap nicely alongside the close button',
+          { persist: true },
+        )
+      "
+    >
+      Persist Long
+    </button>
   </body>
 </html>

--- a/tests/sourdough-toast.spec.js
+++ b/tests/sourdough-toast.spec.js
@@ -31,7 +31,7 @@ test("toast have types", async ({ page }) => {
   await page.getByRole("button", { name: "Success" }).click();
   await expect(page.getByText("Success toast", { exact: true })).toHaveCount(1);
 
-  await page.getByRole("button", { name: "Error" }).click();
+  await page.getByRole("button", { name: "Error", exact: true }).click();
   await expect(page.getByText("Error toast", { exact: true })).toHaveCount(1);
 
   await page.getByRole("button", { name: "Warning" }).click();
@@ -61,21 +61,84 @@ test("clicking close button removes the toast", async ({ page }) => {
 
   await page.locator("[data-close-button]").click();
 
-  await expect(page.locator("[data-sourdough-toast][data-removed='true']")).toBeVisible();
+  await expect(
+    page.locator("[data-sourdough-toast][data-removed='true']"),
+  ).toBeVisible();
 
   await page.waitForTimeout(500);
   await expect(page.locator("[data-sourdough-toast]")).toHaveCount(0);
 });
 
-test("render html in toast description and data-toast-dismiss works", async ({ page }) => {
+test("render html in toast description and data-toast-dismiss works", async ({
+  page,
+}) => {
   await page.getByRole("button", { name: "With HTML" }).click();
 
-  const description = await page.waitForSelector('[data-sourdough-toast] [data-description]');
-  const dismissButton = await description.$('[data-toast-dismiss]');
+  const description = await page.waitForSelector(
+    "[data-sourdough-toast] [data-description]",
+  );
+  const dismissButton = await description.$("[data-toast-dismiss]");
   expect(dismissButton).not.toBeNull();
-  expect(await dismissButton.textContent()).toBe('Confirm');
+  expect(await dismissButton.textContent()).toBe("Confirm");
   await dismissButton.click();
   await page.waitForSelector("[data-sourdough-toast][data-removed='true']");
   await page.waitForTimeout(500);
   await expect(page.locator("[data-sourdough-toast]")).toHaveCount(0);
+});
+
+test("persisted toast does not auto-dismiss", async ({ page }) => {
+  await page.getByRole("button", { name: "Persist", exact: true }).click();
+
+  // Wait beyond the default duration (4s)
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+
+  await expect(page.locator("[data-sourdough-toast]")).toHaveCount(1);
+});
+
+test("persisted toast has close button", async ({ page }) => {
+  await page.getByRole("button", { name: "Persist", exact: true }).click();
+
+  await expect(
+    page.locator("[data-sourdough-toast] [data-close-button]"),
+  ).toHaveCount(1);
+});
+
+test("persisted toast can be dismissed via close button", async ({ page }) => {
+  await page.getByRole("button", { name: "Persist", exact: true }).click();
+
+  await expect(page.locator("[data-sourdough-toast]")).toHaveCount(1);
+
+  await page.locator("[data-close-button]").click();
+
+  await expect(page.locator("[data-sourdough-toast]")).toHaveCount(0);
+});
+
+test("persisted toasts stack normally with regular toasts", async ({
+  page,
+}) => {
+  await page.getByRole("button", { name: "Basic" }).click();
+  await page.getByRole("button", { name: "Persist", exact: true }).click();
+
+  const toasts = page.locator("[data-sourdough-toast]");
+  await expect(toasts).toHaveCount(2);
+
+  // Persisted toast is second (created after basic), so it gets the higher z-index
+  const regularZIndex = await toasts
+    .filter({ hasNotText: "Persistent toast" })
+    .evaluate((el) => el.style.getPropertyValue("--z-index"));
+  const persistedZIndex = await toasts
+    .filter({ hasText: "Persistent toast" })
+    .evaluate((el) => el.style.getPropertyValue("--z-index"));
+
+  expect(Number(persistedZIndex)).toBeGreaterThan(Number(regularZIndex));
+});
+
+test("persisted toasts don't count toward maxToasts", async ({ page }) => {
+  await page.getByRole("button", { name: "Persist", exact: true }).click();
+  await page.getByRole("button", { name: "Basic" }).click();
+  await page.getByRole("button", { name: "Basic" }).click();
+  await page.getByRole("button", { name: "Basic" }).click();
+
+  // 3 regular (maxToasts) + 1 persisted = 4 visible
+  await expect(page.locator("[data-sourdough-toast]")).toHaveCount(4);
 });


### PR DESCRIPTION
This pull request introduces support for persistent toasts in the sourdough-toast library. Persistent toasts remain visible until dismissed by the user and do not auto-dismiss after a timeout. The implementation includes changes to both the JavaScript logic and CSS styling, as well as updates to the documentation and tests to demonstrate and verify the new feature.

### Persistent toast feature

* Added a `persist` option to the toast API, allowing toasts to remain until manually dismissed. Persistent toasts do not auto-dismiss, and their close button is always visible. (`src/sourdough-toast.js`, `example/index.html`, `tests/index.html`) [[1]](diffhunk://#diff-493c1a23a1caa678cdd88fa15e1ea26a4d9081c16acd66a0c1d6e78896694da9R386-R389) [[2]](diffhunk://#diff-493c1a23a1caa678cdd88fa15e1ea26a4d9081c16acd66a0c1d6e78896694da9L549-R565) [[3]](diffhunk://#diff-3ee232a310ee722612ee4c129240a701e053e1421356094e6de048f91db1aa2dR142-R144) [[4]](diffhunk://#diff-90b511c392b35b916f8651ba3b27fea4341761dd54aedaec91c52a757e545667L31-R63)
* Persistent toasts are excluded from the `maxToasts` stacking limit, so they can coexist with the maximum number of regular toasts. (`src/sourdough-toast.js`)

### UI and styling updates

* Adjusted CSS to ensure persistent toasts display a close button with reduced opacity, which increases on hover. Also added padding for close buttons in toasts. (`src/sourdough-toast.css`) [[1]](diffhunk://#diff-e91e58835a055ab06f8ba3c53774905a8b72692f1d419a74034709daf39ff7edR172-R175) [[2]](diffhunk://#diff-e91e58835a055ab06f8ba3c53774905a8b72692f1d419a74034709daf39ff7edR250-R257)

### Test and documentation improvements

* Added new tests to verify persistent toast behaviors, including stacking, manual dismissal, and exclusion from the maxToasts limit. (`tests/sourdough-toast.spec.js`)
* Updated demo and test HTML files to include persistent toast examples. (`example/index.html`, `tests/index.html`) [[1]](diffhunk://#diff-3ee232a310ee722612ee4c129240a701e053e1421356094e6de048f91db1aa2dR142-R144) [[2]](diffhunk://#diff-90b511c392b35b916f8651ba3b27fea4341761dd54aedaec91c52a757e545667L31-R63)

### Minor code and test cleanups

* Improved test selector accuracy and formatting for better reliability and readability. (`tests/sourdough-toast.spec.js`)